### PR TITLE
Use default livecheck strategy for drata-agent

### DIFF
--- a/Casks/drata-agent.rb
+++ b/Casks/drata-agent.rb
@@ -9,7 +9,6 @@ cask "drata-agent" do
 
   livecheck do
     url :url
-    strategy :github_latest
   end
 
   auto_updates true


### PR DESCRIPTION
Documentation suggests we only use GithubLatest strategy when the default Git strategy doesn't work.