### PR TITLE
Autoupdate tap

### DIFF
--- a/.github/workflows/update-tap.yml
+++ b/.github/workflows/update-tap.yml
@@ -1,0 +1,21 @@
+name: "Update Tap"
+
+on:
+  schedule:
+    # 0808 every day
+    - cron: "8 8 * * *"
+
+jobs:
+  update-tap:
+    runs-on: "macos-latest"
+    steps:
+      - name: "Checkout Repo"
+        uses: "actions/checkout@v2"
+      - name: "Bump Formula"
+        uses: "dawidd6/action-homebrew-bump-formula@v3"
+        continue-on-error: true
+        with:
+          force: false
+          livecheck: true
+          tap: "caius/tap"
+          token: "${{ secrets.TOKEN }}"

--- a/Formula/terraform@1.0.11.rb
+++ b/Formula/terraform@1.0.11.rb
@@ -8,7 +8,7 @@ class TerraformAT1011 < Formula
 
   livecheck do
     url "https://releases.hashicorp.com/terraform/"
-    regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]}i)
+    regex(%r{href=.*?v?(1\.0(?:\.\d+))/?["' >]}i)
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
## What?

- [x] Added action to open PRs for cask/formula updates

## Why?

Bored of running `brew livecheck` locally, easiest to just merge PRs. Drata doesn't update much, but saves me some busywork when it does.
