### PR TITLE
Fix livecheck in formula

### DIFF
--- a/Formula/nomctx.rb
+++ b/Formula/nomctx.rb
@@ -1,16 +1,12 @@
 class Nomctx < Formula
   sha256 "d06fba7993adde57f337135be7d6ace19393229f6518ce9c883fafebb5530326"
 
-  url "https://github.com/mr-karan/nomctx/archive/v0.2.7.tar.gz"
+  url "https://github.com/mr-karan/nomctx/archive/refs/tags/v0.2.7.tar.gz"
   desc "Faster way to switch between clusters and namespaces in nomad"
   homepage "https://github.com/mr-karan/nomctx"
   license "MIT"
 
   head "https://github.com/mr-karan/nomctx.git", branch: "master"
-
-  livecheck do
-    url :url
-  end
 
   depends_on "go" => :build
 
@@ -22,6 +18,6 @@ class Nomctx < Formula
   end
 
   test do
-    assert_equal "pgmetrics: /dev/null: EOF", `#{bin}/pgmetrics -i /dev/null 2>/dev/stdout`.chomp
+    assert_equal "nomctx version #{version}", `#{bin}/nomctx --version`.chomp
   end
 end

--- a/Formula/pgmetrics.rb
+++ b/Formula/pgmetrics.rb
@@ -8,10 +8,6 @@ class Pgmetrics < Formula
 
   head "https://github.com/rapidloop/pgmetrics.git", branch: "master"
 
-  livecheck do
-    url :url
-  end
-
   depends_on "go" => :build
 
   def install


### PR DESCRIPTION
## What?

- [x] Use defaults for formula when livechecking
    - nomctx
    - pgmetrics

## Why?

They're broken, `url :url` doesn't work anymore. The defaults of using a GitHub release tag archive file works with Livecheck though, so we can just lean on the defaults for them.